### PR TITLE
Be smarter about checking the collectd module.

### DIFF
--- a/collectd_haproxy/__init__.py
+++ b/collectd_haproxy/__init__.py
@@ -1,7 +1,8 @@
 try:
     import collectd
+    collectd.register_config
     collectd_present = True
-except ImportError:
+except (ImportError, AttributeError):
     collectd_present = False
 
 from .plugin import HAProxyPlugin


### PR DESCRIPTION
Collectd's python api works by exposing a module called "collectd",
which unfortunately conflicts with a completely separate module
available on pypi called "collectd" as well.

In order to determine that the embeded collectd module is present we
just check if register_config() is present and watch for the
AttributeError if it isn't.

Fixes #1
