### PR TITLE
Use code climate for quality reporting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ envs:
   - TOXENV=py27
   - TOXENV=py35
 before_install:
-  - pip install codecov
+  - pip install codeclimate-test-reporter
 install: pip install tox
 script: tox
 after_success:
-  - codecov
+  - codeclimate-test-reporter

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ HAProxy stats for Collectd
     https://travis-ci.org/wglass/collectd-haproxy.svg?branch=master
     :alt: Build Status
     :target: https://travis-ci.org/wglass/collectd-haproxy
-.. image:: https://landscape.io/github/wglass/collectd-haproxy/master/landscape.svg?style=flat
-   :alt: Code Health
-   :target: https://landscape.io/github/wglass/collectd-haproxy/master
+.. image:: https://codeclimate.com/github/wglass/collectd-haproxy/badges/gpa.svg
+   :alt: Code Climate
+   :target: https://codeclimate.com/github/wglass/collectd-haproxy
 
 A plugin for collectd_ to gather metrics for a local HAProxy_ instance, with a
 focus on easy installation and configuration.


### PR DESCRIPTION
Landscape has been having issues with hanging builds, and code coverage's coverage feature for python is finally here.
