### PR TITLE
Fix encoding for python 3, test coverage to 100%

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,3 @@
-languages:
-  Python: true
 engines:
   pep8:
     enabled: true

--- a/collectd_haproxy/compat.py
+++ b/collectd_haproxy/compat.py
@@ -31,6 +31,6 @@ def coerce_long(string):
     :type string: str
     """
     if not PY3:
-        return long(string)  # noqa
+        return long(string)  # pragma: no cover
 
     return int(string)

--- a/collectd_haproxy/connection.py
+++ b/collectd_haproxy/connection.py
@@ -1,7 +1,7 @@
 try:
     from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+except ImportError:  # pragma: no cover
+    from io import StringIO  # pragma: no cover
 import errno
 import socket
 

--- a/collectd_haproxy/connection.py
+++ b/collectd_haproxy/connection.py
@@ -65,7 +65,7 @@ class HAProxySocket(object):
             try:
                 chunk = sock.recv(SOCKET_BUFFER_SIZE)
                 if chunk:
-                    buff.write(chunk)
+                    buff.write(chunk.decode("ascii"))
                 else:
                     break
             except IOError as e:
@@ -89,17 +89,16 @@ class HAProxySocket(object):
         :param response: The full response string from running the command.
         :type response: str
         """
-        if response.startswith(b"Unknown command."):
+        if response.startswith("Unknown command."):
             self.collectd.error("Unknown HAProxy command: %s" % command)
             return ""
-        if response == b"Permission denied.\n":
+        if response == "Permission denied.\n":
             self.collectd.error("Permission denied for command: %s" % command)
             return ""
-        if response == b"No such backend.\n":
+        if response == "No such backend.\n":
             self.collectd.error("No such server: '%s'" % command)
             return ""
 
-        response = response.decode()
         return response.rstrip("\n")
 
     def gen_info(self):

--- a/tests/example_stats.csv
+++ b/tests/example_stats.csv
@@ -1,0 +1,7 @@
+# pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt,comp_in,comp_out,comp_byp,comp_rsp,lastsess,last_chk,last_agt,qtime,ctime,rtime,ttime,
+frontend,FRONTEND,,,41,103,50000,2532247,16099928579,10523206007,0,0,44092,,,,,OPEN,,,,,,,,,1,2,0,,,,0,18,0,64,,,,0,1793812,677495,59183,1495,224,,20,62,2532219,,,0,0,0,0,,,,,,,,
+appservers,FRONTEND,,,4,31,2000,123649,116870367,2700571476,0,0,1,,,,,OPEN,,,,,,,,,1,3,0,,,,0,0,0,13,,,,0,146509,56,111,0,0,,1,45,146676,,,0,0,0,0,,,,,,,,
+appservers,app01_8080,0,0,0,1,150,1706,3315084,69107350,,0,,0,0,0,0,UP,1,1,0,19,0,104601,0,,1,3,1,,1706,,2,0,,2,L7OK,200,2,0,1703,2,1,0,0,0,,,,0,0,,,,,33,OK,,0,0,54,430,
+appservers,app01_8081,0,0,0,1,150,1707,3329952,78953237,,0,,0,0,0,0,UP,1,1,0,16,0,104601,0,,1,3,2,,1707,,2,0,,1,L7OK,200,2,0,1703,3,1,0,0,0,,,,0,0,,,,,37,OK,,0,0,52,494,
+appservers,app02_8080,0,0,0,1,150,1707,3312974,89028346,,0,,0,0,0,0,UP,1,1,0,15,0,104601,0,,1,3,3,,1707,,2,0,,1,L7OK,200,1,0,1700,2,5,0,0,0,,,,0,0,,,,,15,OK,,0,0,56,458,
+appservers,BACKEND,0,0,0,5,200,54760,117292030,2700706403,0,0,,0,0,0,0,UP,32,32,0,,0,104913,0,,1,3,0,,54760,,1,1,,45,,,,0,54594,56,110,0,0,,,,,0,0,0,0,0,0,0,,,0,0,11,928,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,387 @@
+import errno
+import os
+import unittest
+
+from mock import patch, Mock
+
+from collectd_haproxy.connection import HAProxySocket
+
+
+class HAProxySocketTests(unittest.TestCase):
+
+    def setUp(self):
+        super(HAProxySocketTests, self).setUp()
+
+        self.connected_to = None
+        self.response_chunks = []
+
+        def get_next_response_chunk(*args):
+            chunk = self.response_chunks.pop(0)
+            if isinstance(chunk, Exception):
+                raise chunk
+            else:
+                return chunk
+
+        socket_patcher = patch("collectd_haproxy.connection.socket")
+
+        mock_socket = socket_patcher.start()
+        self.addCleanup(socket_patcher.stop)
+
+        self.socket = mock_socket.socket.return_value
+
+        self.socket.recv.side_effect = get_next_response_chunk
+
+    def test_send_command_connection_refused(self):
+        collectd = Mock()
+
+        self.socket.connect.side_effect = IOError(errno.ECONNREFUSED, "")
+
+        s = HAProxySocket(collectd, "/var/run/sock.sock")
+
+        result = s.send_command("a command")
+
+        self.socket.connect.assert_called_once_with("/var/run/sock.sock")
+        self.assertEqual(result, None)
+
+        collectd.error.assert_called_once_with(
+            "Connection refused.  Is HAProxy running?"
+        )
+
+    def test_send_command_othererror_connecting(self):
+        collectd = Mock()
+
+        self.socket.connect.side_effect = IOError(errno.ENETUNREACH)
+
+        s = HAProxySocket(collectd, "/var/run/sock.sock")
+
+        with self.assertRaises(IOError):
+            s.send_command("a command")
+
+    def test_send_command_unreliable_network(self):
+        collectd = Mock()
+
+        self.response_chunks = [
+            IOError(errno.EAGAIN, ""),
+            b"this is\n",
+            b"a\n",
+            IOError(errno.EINTR, ""),
+            b" fake response\n\n",
+            None
+        ]
+
+        s = HAProxySocket(collectd, "/var/run/sock.sock")
+
+        result = s.send_command("a command")
+
+        self.socket.sendall.assert_called_once_with(b"a command\n")
+
+        self.assertEqual(
+            result,
+            """this is
+a
+ fake response"""
+        )
+
+    def test_send_command_error_when_sending(self):
+        collectd = Mock()
+
+        self.response_chunks = [
+            IOError(errno.ECONNREFUSED, ""),
+        ]
+
+        s = HAProxySocket(collectd, "/var/run/sock.sock")
+
+        with self.assertRaises(IOError):
+            s.send_command("a command")
+
+    def test_send_command_unknown_command(self):
+        collectd = Mock()
+
+        self.response_chunks = [b"Unknown command.\n", None]
+
+        s = HAProxySocket(collectd, "/var/run/sock.sock")
+
+        result = s.send_command("a command")
+
+        self.assertEqual(result, "")
+
+        collectd.error.assert_called_once_with(
+            "Unknown HAProxy command: a command"
+        )
+
+    def test_send_command_permission_denied(self):
+        collectd = Mock()
+
+        self.response_chunks = [b"Permission denied.\n", None]
+
+        s = HAProxySocket(collectd, "/var/run/sock.sock")
+
+        result = s.send_command("other command")
+
+        self.assertEqual(result, "")
+
+        collectd.error.assert_called_once_with(
+            "Permission denied for command: other command"
+        )
+
+    def test_send_command_unknown_backend(self):
+        collectd = Mock()
+
+        self.response_chunks = [b"No such backend.\n", None]
+
+        s = HAProxySocket(collectd, "/var/run/sock.sock")
+
+        result = s.send_command("restart app09")
+
+        self.assertEqual(result, "")
+
+        collectd.error.assert_called_once_with(
+            "No such server: 'restart app09'"
+        )
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_info(self, send_command):
+        send_command.return_value = """Version: 1.6.6
+CurrConns: 20
+OtherInfo: ok"""
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        self.assertEqual(
+            list(s.gen_info()),
+            [
+                ("Version", "1.6.6"),
+                ("CurrConns", "20"),
+                ("OtherInfo", "ok"),
+            ]
+        )
+
+        send_command.assert_called_once_with("show info")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_info_no_legit_response(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        self.assertEqual(list(s.gen_info()), [])
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats_no_legit_response(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=True,
+            include_backends=True,
+            include_servers=True
+        )
+
+        self.assertEqual(list(result), [])
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats__frontend_backend_server(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=True,
+            include_backends=True,
+            include_servers=True
+        )
+
+        list(result)
+
+        send_command.assert_called_once_with("show stat -1 7 -1")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats__backend_server(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=False,
+            include_backends=True,
+            include_servers=True
+        )
+
+        list(result)
+
+        send_command.assert_called_once_with("show stat -1 6 -1")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats__frontend_server(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=True,
+            include_backends=False,
+            include_servers=True
+        )
+
+        list(result)
+
+        send_command.assert_called_once_with("show stat -1 5 -1")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats__frontend_backend(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=True,
+            include_backends=True,
+            include_servers=False
+        )
+
+        list(result)
+
+        send_command.assert_called_once_with("show stat -1 3 -1")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats__frontend(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=True,
+            include_backends=False,
+            include_servers=False
+        )
+
+        list(result)
+
+        send_command.assert_called_once_with("show stat -1 1 -1")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats__backend(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=False,
+            include_backends=True,
+            include_servers=False
+        )
+
+        list(result)
+
+        send_command.assert_called_once_with("show stat -1 2 -1")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats__servers(self, send_command):
+        send_command.return_value = None
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=False,
+            include_backends=False,
+            include_servers=True
+        )
+
+        list(result)
+
+        send_command.assert_called_once_with("show stat -1 4 -1")
+
+    @patch.object(HAProxySocket, "send_command")
+    def test_gen_stats(self, send_command):
+        example_stats = None
+        example_stats_file = os.path.join(
+            os.path.dirname(__file__), "./example_stats.csv"
+        )
+
+        with open(example_stats_file, "r") as fd:
+            example_stats = fd.read()
+
+        send_command.return_value = example_stats.rstrip("\n")
+
+        s = HAProxySocket(Mock(), "/var/run/sock.sock")
+
+        result = s.gen_stats(
+            include_frontends=True,
+            include_backends=True,
+            include_servers=True
+        )
+
+        result = list(result)
+
+        proxy_name, values = result[0]
+
+        self.assertEqual(proxy_name, "frontend")
+
+        self.assertEqual(
+            values,
+            {
+                "": "",
+                "act": "",
+                "bck": "",
+                "bin": "16099928579",
+                "bout": "10523206007",
+                "check_code": "",
+                "check_duration": "",
+                "check_status": "",
+                "chkdown": "",
+                "chkfail": "",
+                "cli_abrt": "",
+                "comp_byp": "0",
+                "comp_in": "0",
+                "comp_out": "0",
+                "comp_rsp": "0",
+                "ctime": "",
+                "downtime": "",
+                "dreq": "0",
+                "dresp": "0",
+                "econ": "",
+                "ereq": "44092",
+                "eresp": "",
+                "hanafail": "",
+                "hrsp_1xx": "0",
+                "hrsp_2xx": "1793812",
+                "hrsp_3xx": "677495",
+                "hrsp_4xx": "59183",
+                "hrsp_5xx": "1495",
+                "hrsp_other": "224",
+                "iid": "2",
+                "last_agt": "",
+                "last_chk": "",
+                "lastchg": "",
+                "lastsess": "",
+                "lbtot": "",
+                "pid": "1",
+                "qcur": "",
+                "qlimit": "",
+                "qmax": "",
+                "qtime": "",
+                "rate": "18",
+                "rate_lim": "0",
+                "rate_max": "64",
+                "req_rate": "20",
+                "req_rate_max": "62",
+                "req_tot": "2532219",
+                "rtime": "",
+                "scur": "41",
+                "sid": "0",
+                "slim": "50000",
+                "smax": "103",
+                "srv_abrt": "",
+                "status": "OPEN",
+                "stot": "2532247",
+                "svname": "FRONTEND",
+                "throttle": "",
+                "tracked": "",
+                "ttime": "",
+                "type": "0",
+                "weight": "",
+                "wredis": "",
+                "wretr": "",
+            }
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,4 @@ deps=
     pytest-cov
     mock
     flake8
-commands = pytest --cov=collectd_haproxy {toxinidir}/tests
+commands = pytest --cov=collectd_haproxy --cov-report= {toxinidir}/tests


### PR DESCRIPTION
Adds full coverage to the connection.py module, fixing an encoding bug found along the way.

The bug only applied to python 3, merely an oversight of bytes vs strings api changes.
