### PR TITLE
Get the plugin working for python 2.6.

### DIFF
--- a/collectd_haproxy/plugin.py
+++ b/collectd_haproxy/plugin.py
@@ -100,12 +100,11 @@ class HAProxyPlugin(object):
         `HAProxySocket` for fetching the values.
         """
         self.collectd.debug("initializing")
-        self.metrics = {
-            metric_name: self.collectd.Values(
+        self.metrics = {}
+        for metric_name, xref in iteritems(METRIC_XREF):
+            self.metrics[metric_name] = self.collectd.Values(
                 plugin=self.name, type=xref[1], type_instance=xref[0]
             )
-            for metric_name, xref in iteritems(METRIC_XREF)
-        }
 
         self.socket = HAProxySocket(self.collectd, self.socket_file_path)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,9 @@
 import errno
 import os
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from mock import patch, Mock
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,7 @@
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from mock import Mock, patch, call
 

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from flake8.api import legacy as flake8
 
@@ -7,6 +8,10 @@ from collectd_haproxy import compat
 
 DIRS_TO_TEST = ("collectd_haproxy", "tests")
 MAX_COMPLEXITY = 11
+
+
+# flake8 does not work on python 2.6 or lower
+__test__ = sys.version_info >= (2, 7)
 
 
 def test_style():

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py27,py35
+envlist = py26,py27,py35
 skipsdist = True
 
 [testenv]
 usedevelop = True
 deps=
+    py26: unittest2
     pytest
     pytest-cov
     mock


### PR DESCRIPTION
A simple matter really:
- Remove a use of a dictionary comprehension
- Add python 2.6 as a tox target
- Use the unittest2 backport when on 2.6

Fixes #6
